### PR TITLE
Add notarization step in the CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ env:
   MCUBOOT_PATH: ${{ github.workspace }}/mcuboot
   IMGTOOL_PACKING_PATH: ${{ github.workspace }}/imgtool-packing
 
-
 on:
   push:
     tags:
@@ -84,19 +83,19 @@ jobs:
         if: matrix.os == 'windows-latest'
         working-directory: ${{ env.MCUBOOT_PATH }}/scripts/${{ env.DIST_DIR }}
         run: | # we need to create the subdir where to place binaries
-          mkdir ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}
-          mv -v ./${{ env.PROJECT_NAME }}.exe ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}
-          mv -v "${{ env.IMGTOOL_PACKING_PATH }}/LICENSE.txt" ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}
-          7z a ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}.zip ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}
+          mkdir ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
+          mv -v ./${{ env.PROJECT_NAME }}.exe ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
+          mv -v "${{ env.IMGTOOL_PACKING_PATH }}/LICENSE.txt" ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
+          7z a ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}.zip ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
           
       - name: Package
         if: matrix.os != 'windows-latest'
         working-directory: ${{ env.MCUBOOT_PATH }}/scripts/${{ env.DIST_DIR }}
         run: | # we need to create the subdir where to place binaries
-          mkdir ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}
-          mv -v ./${{ env.PROJECT_NAME }} ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}
-          mv -v ${{ env.IMGTOOL_PACKING_PATH }}/LICENSE.txt ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}
-          ${{ matrix.archive_util }} -cz ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }} -f ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}.tar.gz
+          mkdir ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
+          mv -v ./${{ env.PROJECT_NAME }} ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
+          mv -v ${{ env.IMGTOOL_PACKING_PATH }}/LICENSE.txt ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
+          ${{ matrix.archive_util }} -cz ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }} -f ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}.tar.gz
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -161,10 +160,10 @@ jobs:
       - name: Package
         working-directory: ${{ env.MCUBOOT_PATH }}/scripts/${{ env.DIST_DIR }}
         run: | # we need to create the subdir where to place binaries
-          sudo mkdir ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}
-          sudo mv -v ./${{ env.PROJECT_NAME }} ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}
-          sudo mv -v ${{ env.IMGTOOL_PACKING_PATH }}/LICENSE.txt ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}
-          sudo tar -cz ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }} -f ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}.tar.gz #dist dir is created in the container with different user/grp
+          sudo mkdir ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
+          sudo mv -v ./${{ env.PROJECT_NAME }} ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
+          sudo mv -v ${{ env.IMGTOOL_PACKING_PATH }}/LICENSE.txt ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
+          sudo tar -cz ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }} -f ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}.tar.gz #dist dir is created in the container with different user/grp
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Install pyinstaller
-        run: pip install pyinstaller
+        run: pip install pyinstaller==5.0.1
 
       - name: Build
         working-directory: ${{ env.MCUBOOT_PATH }}/scripts/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,9 +172,77 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.MCUBOOT_PATH }}/scripts/dist/${{ env.PROJECT_NAME }}_*
 
+  notarize-macos:
+    runs-on: macos-latest
+    needs: build
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
+
+      - name: Import Code-Signing Certificates
+        env:
+          KEYCHAIN: "sign.keychain"
+          INSTALLER_CERT_MAC_PATH: "/tmp/ArduinoCerts2020.p12"
+          KEYCHAIN_PASSWORD: keychainpassword # Arbitrary password for a keychain that exists only for the duration of the job, so not secret
+        run: |
+          echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode > "${{ env.INSTALLER_CERT_MAC_PATH }}"
+          security create-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
+          security default-keychain -s "${{ env.KEYCHAIN }}"
+          security unlock-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
+          security import \
+            "${{ env.INSTALLER_CERT_MAC_PATH }}" \
+            -k "${{ env.KEYCHAIN }}" \
+            -f pkcs12 \
+            -A \
+            -T "/usr/bin/codesign" \
+            -P "${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}"
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s \
+            -k "${{ env.KEYCHAIN_PASSWORD }}" \
+            "${{ env.KEYCHAIN }}"
+
+      - name: Install gon for code signing and app notarization
+        run: |
+          wget -q https://github.com/mitchellh/gon/releases/download/v0.2.3/gon_macos.zip
+          unzip gon_macos.zip -d /usr/local/bin
+
+      - name: Sign and notarize binary
+        env:
+          AC_USERNAME: ${{ secrets.AC_USERNAME }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+        run: |
+          gon gon.config.hcl
+
+      - name: Re-package binary
+        # This step performs the following:
+        # 1. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
+        run: |
+          # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
+          # so we need to add execution permission back until the action is made to do this.
+          chmod +x ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_macOS_64bit/${{ env.PROJECT_NAME }}
+          TAG="${GITHUB_REF/refs\/tags\//}"
+          tar -czvf "${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz" \
+            -C ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_macOS_64bit/ ${{ env.PROJECT_NAME }} \
+            LICENSE.txt
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
+  
   create-release:
     runs-on: ubuntu-latest
-    needs: [build, build-crosscompile]
+    needs: [build, build-crosscompile, notarize-macos]
 
     steps:
       - name: Download artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,17 +76,17 @@ jobs:
         run: pip install pyinstaller==5.0.1
 
       - name: Build
-        if: matrix.os != 'macos-10.15'
+        if: runner.os != 'macOS'
         working-directory: ${{ env.MCUBOOT_PATH }}/scripts/
         run: pyinstaller --onefile main.py -n ${{ env.PROJECT_NAME }}
 
       - name: Build macOS
-        if: matrix.os == 'macos-10.15'
+        if: runner.os == 'macOS'
         working-directory: ${{ env.MCUBOOT_PATH }}/scripts/
         run: pyinstaller --osx-entitlements-file ${{ env.IMGTOOL_PACKING_PATH }}/entitlements.plist --onefile main.py -n ${{ env.PROJECT_NAME }}
 
       - name: Package
-        if: matrix.os == 'windows-latest'
+        if: runner.os == 'Windows'
         working-directory: ${{ env.MCUBOOT_PATH }}/scripts/${{ env.DIST_DIR }}
         run: | # we need to create the subdir where to place binaries
           mkdir ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
@@ -95,7 +95,7 @@ jobs:
           7z a ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}.zip ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
           
       - name: Package
-        if: matrix.os != 'windows-latest'
+        if: runner.os != 'Windows'
         working-directory: ${{ env.MCUBOOT_PATH }}/scripts/${{ env.DIST_DIR }}
         run: | # we need to create the subdir where to place binaries
           mkdir ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,14 @@ jobs:
         run: pip install pyinstaller==5.0.1
 
       - name: Build
+        if: matrix.os != 'macos-10.15'
         working-directory: ${{ env.MCUBOOT_PATH }}/scripts/
         run: pyinstaller --onefile main.py -n ${{ env.PROJECT_NAME }}
+
+      - name: Build macOS
+        if: matrix.os == 'macos-10.15'
+        working-directory: ${{ env.MCUBOOT_PATH }}/scripts/
+        run: pyinstaller --osx-entitlements-file ${{ env.IMGTOOL_PACKING_PATH }}/entitlements.plist --onefile main.py -n ${{ env.PROJECT_NAME }}
 
       - name: Package
         if: matrix.os == 'windows-latest'

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ apt-get install -y upx
 python -m pip install --upgrade pip setuptools wheel
 cd workspace/
 pip install -r requirements.txt
-pip install pyinstaller==4.2
+pip install pyinstaller==5.0.1
 echo "
 ---
 Available PyInstaller bootloaders:"

--- a/entitlements.plist
+++ b/entitlements.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <!--
+    These are required for binaries built by PyInstaller.
+    For more info, see:
+      https://developer.apple.com/documentation/security/hardened_runtime
+      https://github.com/pyinstaller/pyinstaller/issues/4629
+  -->
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+	  <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/gon.config.hcl
+++ b/gon.config.hcl
@@ -5,6 +5,7 @@ bundle_id = "cc.arduino.imgtool"
 
 sign {
   application_identity = "Developer ID Application: ARDUINO SA (7KT7ZWMCJT)"
+  entitlements_file = "entitlements.plist"
 }
 
 # Ask Gon for zip output to force notarization process to take place.

--- a/gon.config.hcl
+++ b/gon.config.hcl
@@ -1,0 +1,14 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/general/gon.config.hcl
+# See: https://github.com/mitchellh/gon#configuration-file
+source = ["dist/imgtool_macOS_64bit/imgtool"]
+bundle_id = "cc.arduino.imgtool"
+
+sign {
+  application_identity = "Developer ID Application: ARDUINO SA (7KT7ZWMCJT)"
+}
+
+# Ask Gon for zip output to force notarization process to take place.
+# The CI will ignore the zip output, using the signed binary only.
+zip {
+  output_path = "unused.zip"
+}


### PR DESCRIPTION
At the beginning we thought to integrate the key generation inside the arduino-cli, the use of `imgtool` as a standalone tool was not a requirement. It was later decided to write a [guide](https://docs.arduino.cc/tutorials/portenta-h7/secure-boot) on how to properly use `imgtool` in its standalone form. Since the CI does not run notarization for MacOS binaries, the tool is marked with the `com.apple.quarantine` Xattr on Mac. This can be mitigated by adding The notarization step to the CI.