### PR TITLE
Add version to the binary during build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,11 +58,11 @@ jobs:
         
       - name: Set the version
         working-directory: ${{ env.IMGTOOL_PACKING_PATH }}/patches/
-        run: sed -i "s/ARDUINO_VERSION_PLACEHOLDER/${GITHUB_REF/refs\/tags\//}/" 0008-Imgtool-Append-arduino-to-version-string.patch
+        run: perl -pi -e "s/ARDUINO_VERSION_PLACEHOLDER/${GITHUB_REF/refs\/tags\//}/g" 0008-Imgtool-Append-arduino-to-version-string.patch
 
       - name: Apply patches
         working-directory: ${{ env.MCUBOOT_PATH }}/scripts/
-        run: git apply -v "${{ env.IMGTOOL_PACKING_PATH }}/patches/"*
+        run: git apply -v "${{ env.IMGTOOL_PACKING_PATH }}/patches/"*.patch
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v3
@@ -140,11 +140,11 @@ jobs:
 
       - name: Set the version
         working-directory: ${{ env.IMGTOOL_PACKING_PATH }}/patches/
-        run: sed -i "s/ARDUINO_VERSION_PLACEHOLDER/${GITHUB_REF/refs\/tags\//}/" 0008-Imgtool-Append-arduino-to-version-string.patch
+        run: perl -pi -e "s/ARDUINO_VERSION_PLACEHOLDER/${GITHUB_REF/refs\/tags\//}/g" 0008-Imgtool-Append-arduino-to-version-string.patch
 
       - name: Apply patches
         working-directory: ${{ env.MCUBOOT_PATH }}/scripts/
-        run: git apply -v "${{ env.IMGTOOL_PACKING_PATH }}/patches/"*
+        run: git apply -v "${{ env.IMGTOOL_PACKING_PATH }}/patches/"*.patch
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.IMGTOOL_PACKING_PATH }}
+        
+      - name: Set the version
+        working-directory: ${{ env.IMGTOOL_PACKING_PATH }}/patches/
+        run: sed -i "s/ARDUINO_VERSION_PLACEHOLDER/${GITHUB_REF/refs\/tags\//}/" 0008-Imgtool-Append-arduino-to-version-string.patch
 
       - name: Apply patches
         working-directory: ${{ env.MCUBOOT_PATH }}/scripts/
@@ -133,6 +137,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.IMGTOOL_PACKING_PATH }}
+
+      - name: Set the version
+        working-directory: ${{ env.IMGTOOL_PACKING_PATH }}/patches/
+        run: sed -i "s/ARDUINO_VERSION_PLACEHOLDER/${GITHUB_REF/refs\/tags\//}/" 0008-Imgtool-Append-arduino-to-version-string.patch
 
       - name: Apply patches
         working-directory: ${{ env.MCUBOOT_PATH }}/scripts/

--- a/patches/0008-Imgtool-Append-arduino-to-version-string.patch
+++ b/patches/0008-Imgtool-Append-arduino-to-version-string.patch
@@ -1,7 +1,7 @@
 From bc65a76a48fe688bf9e9ce3efe90973976cf400a Mon Sep 17 00:00:00 2001
 From: pennam <m.pennasilico@arduino.cc>
 Date: Mon, 18 Oct 2021 09:41:39 +0200
-Subject: [PATCH] Imgtool: Append -arduino to version string
+Subject: [PATCH] Imgtool: Add version placeholder, can be customized during build
 
 ---
  scripts/imgtool/__init__.py | 2 +-
@@ -16,7 +16,7 @@ index ca43b8d..20769a4 100644
  # limitations under the License.
  
 -imgtool_version = "1.8.0"
-+imgtool_version = "1.8.0-arduino"
++imgtool_version = "ARDUINO_VERSION_PLACEHOLDER"
 -- 
 2.30.2
 


### PR DESCRIPTION
Replace the string in the patch overriding the version, This way when running `imgtool version` the correct version is reported.