### PR TITLE
Add `package_index.template` generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,14 +114,12 @@ jobs:
     name: build (${{ matrix.package_platform }})
     strategy:
       matrix:
-        package_platform: [Linux_32bit, Linux_ARMv6, Linux_ARMv7, Linux_ARM64]
+        package_platform: [Linux_32bit, Linux_ARMv6, Linux_ARM64]
         include:
           - package_platform: Linux_32bit
             docker_image: i386/python:3.7-buster
           - package_platform: Linux_ARMv6
             docker_image: arm32v5/python:3.7-buster # buster is not available for arm32v6, but should be backward compatible
-          - package_platform: Linux_ARMv7
-            docker_image: arm32v7/python:3.7-buster
           - package_platform: Linux_ARM64
             docker_image: arm64v8/python:3.7-buster
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,7 @@ jobs:
         working-directory: ${{ env.MCUBOOT_PATH }}/scripts/${{ env.DIST_DIR }}
         run: | # we need to create the subdir where to place binaries
           mkdir ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
+          chmod +x ./${{ env.PROJECT_NAME }}
           mv -v ./${{ env.PROJECT_NAME }} ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
           mv -v ${{ env.IMGTOOL_PACKING_PATH }}/LICENSE.txt ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
           ${{ matrix.archive_util }} -cz ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }} -f ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}.tar.gz
@@ -165,6 +166,7 @@ jobs:
         working-directory: ${{ env.MCUBOOT_PATH }}/scripts/${{ env.DIST_DIR }}
         run: | # we need to create the subdir where to place binaries
           sudo mkdir ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
+          sudo chmod +x ./${{ env.PROJECT_NAME }}
           sudo mv -v ./${{ env.PROJECT_NAME }} ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
           sudo mv -v ${{ env.IMGTOOL_PACKING_PATH }}/LICENSE.txt ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }}
           sudo tar -cz ${{ env.PROJECT_NAME }}_${{ matrix.package_platform }} -f ${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${{ matrix.package_platform }}.tar.gz #dist dir is created in the container with different user/grp
@@ -249,6 +251,9 @@ jobs:
     needs: [build, build-crosscompile, notarize-macos]
 
     steps:
+      - name: Checkout repository # we need package_index.template
+        uses: actions/checkout@v2
+
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
@@ -264,6 +269,32 @@ jobs:
           unzip -p /tmp/3.2.0.zip semver-tool-3.2.0/src/semver >/tmp/semver && chmod +x /tmp/semver
           if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
 
+      - name: Prepare artifacts for the release and handle package_index
+        run: |
+          package_index=`cat package_index.template | sed s/%%VERSION%%/${GITHUB_REF/refs\/tags\//}/`
+          declare -a target_folders=("Windows_32bit" "Windows_64bit" "Linux_64bit" "macOS_64bit" "Linux_32bit" "Linux_ARMv6" "Linux_ARM64")
+          cd dist
+          for folder in "${target_folders[@]}"
+          do
+            if [[ $folder = "Windows_32bit" || $folder = "Windows_64bit" ]]; then
+              ARCHIVE_NAME=${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${folder}.zip
+            else
+              ARCHIVE_NAME=${{ env.PROJECT_NAME }}_${GITHUB_REF/refs\/tags\//}_${folder}.tar.gz
+            fi
+            T_OS=`echo ${folder} | awk '{print toupper($0)}'`
+            SHASUM=`sha256sum ${ARCHIVE_NAME} | cut -f1 -d" "`
+            SIZE=`stat --printf="%s" ${ARCHIVE_NAME}`
+            package_index=`echo $package_index |
+              sed s/%%FILENAME_${T_OS}%%/${ARCHIVE_NAME}/ |
+              sed s/%%FILENAME_${T_OS}%%/${ARCHIVE_NAME}/ |
+              sed s/%%SIZE_${T_OS}%%/${SIZE}/ |
+              sed s/%%SHA_${T_OS}%%/${SHASUM}/`
+          done
+          cd ..
+          echo ================== CUT ME HERE =====================
+          echo ${package_index}
+          echo ${package_index} > dist/package_index_draft.json
+      
       - name: Create Github Release and upload artifacts
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,11 +255,23 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.DIST_DIR }}
 
+      - name: Identify Prerelease
+        # This is a workaround while waiting for create-release action
+        # to implement auto pre-release based on tag
+        id: prerelease
+        run: |
+          wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.2.0.zip
+          unzip -p /tmp/3.2.0.zip semver-tool-3.2.0/src/semver >/tmp/semver && chmod +x /tmp/semver
+          if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
+
       - name: Create Github Release and upload artifacts
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
+          prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
+          # NOTE: "Artifact is a directory" warnings are expected and don't indicate a problem
+          # (all the files we need are in the DIST_DIR root)
           artifacts: ${{ env.DIST_DIR }}/*
 
       - name: Upload release files on Arduino downloads servers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,8 +292,8 @@ jobs:
           done
           cd ..
           echo ================== CUT ME HERE =====================
-          echo ${package_index}
-          echo ${package_index} > dist/package_index_draft.json
+          echo "${package_index}"
+          echo "${package_index}" > dist/package_index_draft.json
       
       - name: Create Github Release and upload artifacts
         uses: ncipollo/release-action@v1

--- a/package_index.template
+++ b/package_index.template
@@ -1,0 +1,55 @@
+        {
+          "name": "imgtool",
+          "version": "%%VERSION%%",
+          "systems": [
+            {
+              "host": "i386-apple-darwin11",
+              "url": "http://downloads.arduino.cc/tools/%%FILENAME_MACOS_64BIT%%",
+              "archiveFileName": "%%FILENAME_MACOS_64BIT%%",
+              "size": "%%SIZE_MACOS_64BIT%%",
+              "checksum": "SHA-256:%%SHA_MACOS_64BIT%%"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/%%FILENAME_LINUX_ARMV6%%",
+              "archiveFileName": "%%FILENAME_LINUX_ARMV6%%",
+              "size": "%%SIZE_LINUX_ARMV6%%",
+              "checksum": "SHA-256:%%SHA_LINUX_ARMV6%%"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/%%FILENAME_LINUX_ARM64%%",
+              "archiveFileName": "%%FILENAME_LINUX_ARM64%%",
+              "size": "%%SIZE_LINUX_ARM64%%",
+              "checksum": "SHA-256:%%SHA_LINUX_ARM64%%"
+            },
+            {
+              "host": "x86_64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/%%FILENAME_LINUX_64BIT%%",
+              "archiveFileName": "%%FILENAME_LINUX_64BIT%%",
+              "size": "%%SIZE_LINUX_64BIT%%",
+              "checksum": "SHA-256:%%SHA_LINUX_64BIT%%"
+            },
+            {
+              "host": "i686-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/%%FILENAME_LINUX_32BIT%%",
+              "archiveFileName": "%%FILENAME_LINUX_32BIT%%",
+              "size": "%%SIZE_LINUX_32BIT%%",
+              "checksum": "SHA-256:%%SHA_LINUX_32BIT%%"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/%%FILENAME_WINDOWS_32BIT%%",
+              "archiveFileName": "%%FILENAME_WINDOWS_32BIT%%",
+              "size": "%%SIZE_WINDOWS_32BIT%%",
+              "checksum": "SHA-256:%%SHA_WINDOWS_32BIT%%"
+            },
+            {
+              "host": "x86_64-mingw32",
+              "url": "http://downloads.arduino.cc/tools/%%FILENAME_WINDOWS_64BIT%%",
+              "archiveFileName": "%%FILENAME_WINDOWS_64BIT%%",
+              "size": "%%SIZE_WINDOWS_64BIT%%",
+              "checksum": "SHA-256:%%SHA_WINDOWS_64BIT%%"
+            }
+          ]
+        }

--- a/package_index.template
+++ b/package_index.template
@@ -4,49 +4,49 @@
           "systems": [
             {
               "host": "i386-apple-darwin11",
-              "url": "http://downloads.arduino.cc/tools/%%FILENAME_MACOS_64BIT%%",
+              "url": "https://downloads.arduino.cc/tools/%%FILENAME_MACOS_64BIT%%",
               "archiveFileName": "%%FILENAME_MACOS_64BIT%%",
               "size": "%%SIZE_MACOS_64BIT%%",
               "checksum": "SHA-256:%%SHA_MACOS_64BIT%%"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/%%FILENAME_LINUX_ARMV6%%",
+              "url": "https://downloads.arduino.cc/tools/%%FILENAME_LINUX_ARMV6%%",
               "archiveFileName": "%%FILENAME_LINUX_ARMV6%%",
               "size": "%%SIZE_LINUX_ARMV6%%",
               "checksum": "SHA-256:%%SHA_LINUX_ARMV6%%"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/%%FILENAME_LINUX_ARM64%%",
+              "url": "https://downloads.arduino.cc/tools/%%FILENAME_LINUX_ARM64%%",
               "archiveFileName": "%%FILENAME_LINUX_ARM64%%",
               "size": "%%SIZE_LINUX_ARM64%%",
               "checksum": "SHA-256:%%SHA_LINUX_ARM64%%"
             },
             {
               "host": "x86_64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/%%FILENAME_LINUX_64BIT%%",
+              "url": "https://downloads.arduino.cc/tools/%%FILENAME_LINUX_64BIT%%",
               "archiveFileName": "%%FILENAME_LINUX_64BIT%%",
               "size": "%%SIZE_LINUX_64BIT%%",
               "checksum": "SHA-256:%%SHA_LINUX_64BIT%%"
             },
             {
               "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/%%FILENAME_LINUX_32BIT%%",
+              "url": "https://downloads.arduino.cc/tools/%%FILENAME_LINUX_32BIT%%",
               "archiveFileName": "%%FILENAME_LINUX_32BIT%%",
               "size": "%%SIZE_LINUX_32BIT%%",
               "checksum": "SHA-256:%%SHA_LINUX_32BIT%%"
             },
             {
               "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/%%FILENAME_WINDOWS_32BIT%%",
+              "url": "https://downloads.arduino.cc/tools/%%FILENAME_WINDOWS_32BIT%%",
               "archiveFileName": "%%FILENAME_WINDOWS_32BIT%%",
               "size": "%%SIZE_WINDOWS_32BIT%%",
               "checksum": "SHA-256:%%SHA_WINDOWS_32BIT%%"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "http://downloads.arduino.cc/tools/%%FILENAME_WINDOWS_64BIT%%",
+              "url": "https://downloads.arduino.cc/tools/%%FILENAME_WINDOWS_64BIT%%",
               "archiveFileName": "%%FILENAME_WINDOWS_64BIT%%",
               "size": "%%SIZE_WINDOWS_64BIT%%",
               "checksum": "SHA-256:%%SHA_WINDOWS_64BIT%%"


### PR DESCRIPTION
I've removed armv7 binaries since the other tools are not supporting this architecture.
I've added the prerelease check and added the automatic generation and upload of the `package_index.template`