### PR TITLE
Retain newlines in in package index entry generation command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,7 +292,7 @@ jobs:
             T_OS=`echo ${folder} | awk '{print toupper($0)}'`
             SHASUM=`sha256sum ${ARCHIVE_NAME} | cut -f1 -d" "`
             SIZE=`stat --printf="%s" ${ARCHIVE_NAME}`
-            package_index=`echo $package_index |
+            package_index=`echo "$package_index" |
               sed s/%%FILENAME_${T_OS}%%/${ARCHIVE_NAME}/ |
               sed s/%%FILENAME_${T_OS}%%/${ARCHIVE_NAME}/ |
               sed s/%%SIZE_${T_OS}%%/${SIZE}/ |


### PR DESCRIPTION
The previous command discarded all line breaks from the package input snippet generated by the release
workflow, making it more difficult to check visually and to insert into the package index.

```json
{ "name": "imgtool", "version": "1.8.0-arduino.1", "systems": [ { "host": "i386-apple-darwin11", "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_macOS_64bit.tar.gz", "archiveFileName": "imgtool_1.8.0-arduino.1_macOS_64bit.tar.gz", "size": "8449506", "checksum": "SHA-256:8f7448b281f84a803026e2cfb6bc519120725c36d02595906b177cb912c4064e" }, { "host": "arm-linux-gnueabihf", "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Linux_ARMv6.tar.gz", "archiveFileName": "imgtool_1.8.0-arduino.1_Linux_ARMv6.tar.gz", "size": "13471961", "checksum": "SHA-256:3c2865a47e7b58e01f154ee47d661388ca722e39f90c36ef2001e94a1f3fe627" }, { "host": "aarch64-linux-gnu", "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Linux_ARM64.tar.gz", "archiveFileName": "imgtool_1.8.0-arduino.1_Linux_ARM64.tar.gz", "size": "15648727", "checksum": "SHA-256:513fe4c6ed07b798c6719f9b6c6330f7627739ebce495d1bd82f471f0f8c022a" }, { "host": "x86_64-linux-gnu", "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Linux_64bit.tar.gz", "archiveFileName": "imgtool_1.8.0-arduino.1_Linux_64bit.tar.gz", "size": "15574131", "checksum": "SHA-256:521b722f94142dcd4f60a75534279b9729e8c9238bd6b3ef8a6ca08073c2faa9" }, { "host": "i686-linux-gnu", "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Linux_32bit.tar.gz", "archiveFileName": "imgtool_1.8.0-arduino.1_Linux_32bit.tar.gz", "size": "13880511", "checksum": "SHA-256:6d1a69f7e86bfbe0c7d6a61fcb5e5b86bb05dcd783ba3b7f12b666b2e8acd04e" }, { "host": "i686-mingw32", "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Windows_32bit.zip", "archiveFileName": "imgtool_1.8.0-arduino.1_Windows_32bit.zip", "size": "6735725", "checksum": "SHA-256:a02187a6f097cab3c92a7384899125bcff065313a384c0299332d8670dd1085c" }, { "host": "x86_64-mingw32", "url": "https://downloads.arduino.cc/tools/imgtool_1.8.0-arduino.1_Windows_64bit.zip", "archiveFileName": "imgtool_1.8.0-arduino.1_Windows_64bit.zip", "size": "8410920", "checksum": "SHA-256:f0e35e3de59640689a35682c68b8dbf609b53cf29aea9d713edb9a2909f59efa" } ] }
```

This is fixed by adding the missing quoting on a variable.