### PR TITLE
fix mac binary not placed in a top level directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,16 +236,16 @@ jobs:
           gon gon.config.hcl
 
       - name: Re-package binary
+        working-directory: ${{ env.DIST_DIR }}
         # This step performs the following:
         # 1. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         run: |
           # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          chmod +x ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_macOS_64bit/${{ env.PROJECT_NAME }}
+          chmod +x "${{ env.PROJECT_NAME }}_macOS_64bit/${{ env.PROJECT_NAME }}"
           TAG="${GITHUB_REF/refs\/tags\//}"
-          tar -czvf "${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz" \
-            -C ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_macOS_64bit/ ${{ env.PROJECT_NAME }} \
-            LICENSE.txt
+          PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz"
+          tar -czvf "${PACKAGE_FILENAME}" "${{ env.PROJECT_NAME }}_macOS_64bit"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This PR fixes the mac binary not being placed in a top level directory as the other binaries.
Before:
```
$ tar -tvf imgtool_1.8.0-arduino.1_macOS_64bit.tar.gz
-rwxr-xr-x runner/staff 8570880 2022-05-31 12:03 imgtool
-rw-r--r-- runner/staff   11527 2022-05-31 12:01 LICENSE.txt
```
After:
```
$ tar -tvf imgtool_1.8.0-arduino.2-rc2_macOS_64bit.tar.gz
drwxr-xr-x runner/staff      0 2022-07-18 11:04 imgtool_macOS_64bit/
-rwxr-xr-x runner/staff 8576528 2022-07-18 11:04 imgtool_macOS_64bit/imgtool
-rw-r--r-- runner/staff   11527 2022-07-18 11:04 imgtool_macOS_64bit/LICENSE.txt
```