### PR TITLE
Add CI workflow to check for problems with shell scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,60 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/general/.editorconfig
+# See: https://editorconfig.org/
+# The formatting style defined in this file is the official standardized style to be used in all Arduino Tooling
+# projects and should not be modified.
+# Note: indent style for each file type is defined even when it matches the universal config in order to make it clear
+# that this type has an official style.
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{adoc,asc,asciidoc}]
+indent_size = 2
+indent_style = space
+
+[*.{bash,sh}]
+indent_size = 2
+indent_style = space
+
+[*.{c,cc,cp,cpp,cxx,h,hh,hpp,hxx,ii,inl,ino,ixx,pde,tpl,tpp,txx}]
+indent_size = 2
+indent_style = space
+
+[*.{go,mod}]
+indent_style = tab
+
+[*.java]
+indent_size = 2
+indent_style = space
+
+[*.{js,jsx,json,jsonc,json5,ts,tsx}]
+indent_size = 2
+indent_style = space
+
+[*.{md,mdx,mkdn,mdown,markdown}]
+indent_size = unset
+indent_style = space
+
+[*.proto]
+indent_size = 2
+indent_style = space
+
+[*.py]
+indent_size = 4
+indent_style = space
+
+[*.svg]
+indent_size = 2
+indent_style = space
+
+[*.{yaml,yml}]
+indent_size = 2
+indent_style = space
+
+[{.gitconfig,.gitmodules}]
+indent_style = tab

--- a/.github/workflows/check-shell-task.yml
+++ b/.github/workflows/check-shell-task.yml
@@ -1,0 +1,177 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-shell-task.md
+name: Check Shell Scripts
+
+# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+on:
+  create:
+  push:
+    paths:
+      - ".github/workflows/check-shell-task.ya?ml"
+      - "Taskfile.ya?ml"
+      - "**/.editorconfig"
+      - "**.bash"
+      - "**.sh"
+  pull_request:
+    paths:
+      - ".github/workflows/check-shell-task.ya?ml"
+      - "Taskfile.ya?ml"
+      - "**/.editorconfig"
+      - "**.bash"
+      - "**.sh"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by tool changes.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[
+            "${{ github.event_name }}" != "create" ||
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
+  lint:
+    name: ${{ matrix.configuration.name }}
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+
+    env:
+      # See: https://github.com/koalaman/shellcheck/releases/latest
+      SHELLCHECK_RELEASE_ASSET_SUFFIX: .linux.x86_64.tar.xz
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        configuration:
+          - name: Generate problem matcher output
+            # ShellCheck's "gcc" output format is required for annotated diffs, but inferior for humans reading the log.
+            format: gcc
+            # The other matrix job is used to set the result, so this job is configured to always pass.
+            continue-on-error: true
+          - name: ShellCheck
+            # ShellCheck's "tty" output format is most suitable for humans reading the log.
+            format: tty
+            continue-on-error: false
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "INSTALL_PATH=${{ runner.temp }}/shellcheck" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Download latest ShellCheck release binary package
+        id: download
+        uses: MrOctopus/download-asset-action@1.0
+        with:
+          repository: koalaman/shellcheck
+          excludes: prerelease, draft
+          asset: ${{ env.SHELLCHECK_RELEASE_ASSET_SUFFIX }}
+          target: ${{ env.INSTALL_PATH }}
+
+      - name: Install ShellCheck
+        run: |
+          cd "${{ env.INSTALL_PATH }}"
+          tar --extract --file="${{ steps.download.outputs.name }}"
+          EXTRACTION_FOLDER="$(basename "${{ steps.download.outputs.name }}" "${{ env.SHELLCHECK_RELEASE_ASSET_SUFFIX }}")"
+          # Add installation to PATH:
+          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+          echo "${{ env.INSTALL_PATH }}/$EXTRACTION_FOLDER" >> "$GITHUB_PATH"
+
+      - name: Run ShellCheck
+        uses: liskin/gh-problem-matcher-wrap@v1
+        continue-on-error: ${{ matrix.configuration.continue-on-error }}
+        with:
+          linters: gcc
+          run: task --silent shell:check SHELLCHECK_FORMAT=${{ matrix.configuration.format }}
+
+  formatting:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "SHFMT_INSTALL_PATH=${{ runner.temp }}/shfmt" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Download shfmt
+        id: download
+        uses: MrOctopus/download-asset-action@1.0
+        with:
+          repository: mvdan/sh
+          excludes: prerelease, draft
+          asset: _linux_amd64
+          target: ${{ env.SHFMT_INSTALL_PATH }}
+
+      - name: Install shfmt
+        run: |
+          # Executable permissions of release assets are lost
+          chmod +x "${{ env.SHFMT_INSTALL_PATH }}/${{ steps.download.outputs.name }}"
+          # Standardize binary name
+          mv "${{ env.SHFMT_INSTALL_PATH }}/${{ steps.download.outputs.name }}" "${{ env.SHFMT_INSTALL_PATH }}/shfmt"
+          # Add installation to PATH:
+          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+          echo "${{ env.SHFMT_INSTALL_PATH }}" >> "$GITHUB_PATH"
+
+      - name: Format shell scripts
+        run: task --silent shell:format
+
+      - name: Check formatting
+        run: git diff --color --exit-code
+
+  executable:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check for non-executable scripts
+        run: task --silent shell:check-mode

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Check License status](https://github.com/arduino/imgtool-packing/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/imgtool-packing/actions/workflows/check-license.yml)
 [![Check Taskfiles status](https://github.com/arduino/imgtool-packing/actions/workflows/check-taskfiles.yml/badge.svg)](https://github.com/arduino/imgtool-packing/actions/workflows/check-taskfiles.yml)
 [![Check Workflows status](https://github.com/arduino/imgtool-packing/actions/workflows/check-workflows-task.yml/badge.svg)](https://github.com/arduino/imgtool-packing/actions/workflows/check-workflows-task.yml)
+[![Check Shell Scripts status](https://github.com/arduino/imgtool-packing/actions/workflows/check-shell-task.yml/badge.svg)](https://github.com/arduino/imgtool-packing/actions/workflows/check-shell-task.yml)
 
 This repo does not contain the source code, but only the patches, and the release workflow
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -149,3 +149,78 @@ tasks:
         else
           echo "{{.RAW_PATH}}"
         fi
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-shell-task/Taskfile.yml
+  shell:check:
+    desc: Check for problems with shell scripts
+    cmds:
+      - |
+        if ! which shellcheck &>/dev/null; then
+          echo "shellcheck not installed or not in PATH. Please install: https://github.com/koalaman/shellcheck#installing"
+          exit 1
+        fi
+      - |
+        # There is something odd about shellcheck that causes the task to always exit on the first fail, despite any
+        # measures that would prevent this with any other command. So it's necessary to call shellcheck only once with
+        # the list of script paths as an argument. This could lead to exceeding the maximum command length on Windows if
+        # the repository contained a large number of scripts, but it's unlikely to happen in reality.
+        shellcheck \
+          --format={{default "tty" .SHELLCHECK_FORMAT}} \
+          $(
+            # The odd method for escaping . in the regex is required for windows compatibility because mvdan.cc/sh gives
+            # \ characters special treatment on Windows in an attempt to support them as path separators.
+            find . \
+              -type d -name '.git' -prune -or \
+              -type d -name '.licenses' -prune -or \
+              -type d -name '__pycache__' -prune -or \
+              -type d -name 'node_modules' -prune -or \
+              \( \
+                -regextype posix-extended \
+                -regex '.*[.](bash|sh)' -and \
+                -type f \
+              \) \
+              -print
+          )
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-shell-task/Taskfile.yml
+  shell:check-mode:
+    desc: Check for non-executable shell scripts
+    cmds:
+      - |
+        EXIT_STATUS=0
+        while read -r nonExecutableScriptPath; do
+          # The while loop always runs once, even if no file was found
+          if [[ "$nonExecutableScriptPath" == "" ]]; then
+            continue
+          fi
+
+          echo "::error file=${nonExecutableScriptPath}::non-executable script file: $nonExecutableScriptPath";
+          EXIT_STATUS=1
+        done <<<"$(
+          # The odd approach to escaping `.` in the regex is required for windows compatibility because mvdan.cc/sh
+          # gives `\` characters special treatment on Windows in an attempt to support them as path separators.
+          find . \
+            -type d -name '.git' -prune -or \
+            -type d -name '.licenses' -prune -or \
+            -type d -name '__pycache__' -prune -or \
+            -type d -name 'node_modules' -prune -or \
+            \( \
+              -regextype posix-extended \
+              -regex '.*[.](bash|sh)' -and \
+              -type f -and \
+              -not -executable \
+              -print \
+            \)
+        )"
+        exit $EXIT_STATUS
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-shell-task/Taskfile.yml
+  shell:format:
+    desc: Format shell script files
+    cmds:
+      - |
+        if ! which shfmt &>/dev/null; then
+          echo "shfmt not installed or not in PATH. Please install: https://github.com/mvdan/sh#shfmt"
+          exit 1
+        fi
+      - shfmt -w .

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 apt-get update
 apt-get install -y upx
 python -m pip install --upgrade pip setuptools wheel
-cd workspace/
+cd workspace/ || exit
 pip install -r requirements.txt
 pip install pyinstaller==5.0.1
 echo "


### PR DESCRIPTION
On every push or pull request that modifies one of the shell scripts in the repository, and periodically, the workflow:

- Runs [ShellCheck](https://github.com/koalaman/shellcheck) to detect common problems.
- Runs [`shfmt`](https://github.com/mvdan/sh) to check formatting.
- Checks for forgotten executable script file permissions.