### PR TITLE
github: Use IAM Roles to push files on AWS S3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ env:
   PYTHON_VERSION: "3.7"
   MCUBOOT_PATH: ${{ github.workspace }}/mcuboot
   IMGTOOL_PACKING_PATH: ${{ github.workspace }}/imgtool-packing
+  AWS_REGION: "us-east-1"
 
 on:
   push:
@@ -265,7 +266,11 @@ jobs:
 
   create-release:
     runs-on: ubuntu-latest
+    environment: production
     needs: [build, build-crosscompile, notarize-macos]
+    permissions:
+      contents: write
+      id-token: write # This is required for requesting the JWT
 
     steps:
       - name: Checkout repository # we need package_index.template
@@ -323,12 +328,12 @@ jobs:
           # (all the files we need are in the DIST_DIR root)
           artifacts: ${{ env.DIST_DIR }}/*
 
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: "github_${{ env.PROJECT_NAME }}"
+          aws-region: ${{ env.AWS_REGION }}
+
       - name: Upload release files on Arduino downloads servers
-        uses: docker://plugins/s3
-        env:
-          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
-          PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
-          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
-          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: aws s3 sync ${{ env.DIST_DIR }} s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.AWS_PLUGIN_TARGET }}


### PR DESCRIPTION
For security reasons long lived credentials are not considered secure.
To overcome this issue we can configure Github Workflows to use AWS OpenID Connect instead:
For further details: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect

It seems that the build is broken, however since the AWS token are no longer used, we could consider to merge this and if in the future we need to release something we can fix the build in a separate PR.
